### PR TITLE
Fix deployment crash by adding server packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE $PORT
+
+CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "main:flask_app", "--bind", "0.0.0.0:$PORT"]

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: telegram-guides-bot
     env: python
     buildCommand: "pip install -r requirements.txt"
-    startCommand: "uvicorn main:app --host 0.0.0.0 --port 8000"
+    startCommand: "gunicorn -k uvicorn.workers.UvicornWorker main:flask_app --bind 0.0.0.0:$PORT"
     plan: free
     envVars:
       - key: BOT_TOKEN

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 python-telegram-bot[job-queue]
 Flask
+gunicorn
+uvicorn


### PR DESCRIPTION
Fix deployment crash by adding Gunicorn/Uvicorn and configuring the server startup.

The deployment was crashing due to missing server dependencies and an incorrect startup command. This PR adds `gunicorn` and `uvicorn` to the requirements and configures the `Dockerfile` and `render.yaml` to use Gunicorn with Uvicorn workers for the Flask application.

---

[Open in Web](https://cursor.com/agents?id=bc-7cf76cf7-b497-4ea3-b784-4eaf38eaa553) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7cf76cf7-b497-4ea3-b784-4eaf38eaa553)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)