### PR TITLE
Handle message not modified error in button callback

### DIFF
--- a/main.py
+++ b/main.py
@@ -246,7 +246,14 @@ async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         mode_str, page_str = data.split("page:")
         page = int(page_str)
         text, keyboard = build_guides_paginator(page, mode=mode_str)
-        if keyboard: await query.edit_message_text(text, reply_markup=keyboard, parse_mode='MarkdownV2', disable_web_page_preview=True)
+        if keyboard:
+            try:
+                await query.edit_message_text(text, reply_markup=keyboard, parse_mode='MarkdownV2', disable_web_page_preview=True)
+            except telegram.error.BadRequest as e:
+                if "Message is not modified" in str(e):
+                    pass
+                else:
+                    raise
     elif data.startswith("delete:"):
         guide_id_str = data.split(":")[1]
         guide = guides_collection.find_one({"_id": ObjectId(guide_id_str)})


### PR DESCRIPTION
Wrap `edit_message_text` in a try-except to ignore "Message is not modified" errors.

---

[Open in Web](https://cursor.com/agents?id=bc-48f144a3-c495-4e11-8bcf-8ca8d478ae33) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-48f144a3-c495-4e11-8bcf-8ca8d478ae33)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)